### PR TITLE
[querydsl] 검색 조건 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
-	id 'org.springframework.boot' version '2.6.3'
+	id 'org.springframework.boot' version '2.6.0'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
-	id 'war'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.example'
@@ -21,23 +27,72 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
-	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'mysql:mysql-connector-java'
-	runtimeOnly 'com.h2database:h2'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	testImplementation 'org.springframework.batch:spring-batch-test'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+	annotationProcessor(
+			"javax.persistence:javax.persistence-api",
+			"javax.annotation:javax.annotation-api",
+			"com.querydsl:querydsl-apt:${queryDslVersion}:jpa")
+
+	implementation group: 'org.modelmapper', name: 'modelmapper', version: '2.4.4'
+	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.14'
 
 }
 
-tasks.named('test') {
+sourceSets {
+	main {
+		java {
+			srcDirs = ["$projectDir/src/main/java", "$projectDir/build/generated"]
+		}
+	}
+}
+
+test {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+def deleteDir = "$buildDir/generated/"
+
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+
+compileQuerydsl.doFirst {
+	if ( file(deleteDir) ) {
+		delete file(deleteDir)
+		System.out.println("Delete.... queryDir File")
+	}else{
+		System.out.println("DO NOT Delete.... queryDir File")
+	}
+}
+
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
+}
+
+clean {
+	delete file(querydslDir)
 }

--- a/src/main/java/com/example/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/example/guestbook/entity/Guestbook.java
@@ -1,0 +1,34 @@
+package com.example.guestbook.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class Guestbook extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long gno;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 1500, nullable = false)
+    private String content;
+
+    @Column(length = 50, nullable = false)
+    private String writer;
+
+    public void changeTitle(String content){
+        this.title = title;
+    }
+
+    public void changeContent(String content){
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/guestbook/repository/GuestbookRepository.java
+++ b/src/main/java/com/example/guestbook/repository/GuestbookRepository.java
@@ -1,0 +1,8 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Guestbook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+public interface GuestbookRepository extends JpaRepository<Guestbook, Long>, QuerydslPredicateExecutor<Guestbook> {
+}

--- a/src/test/java/com/example/guestbook/repository/GuestbookRepositoryTest.java
+++ b/src/test/java/com/example/guestbook/repository/GuestbookRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Guestbook;
+import com.example.guestbook.entity.QGuestbook;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GuestbookRepositoryTest {
+
+    @Autowired
+    private GuestbookRepository guestbookRepository;
+
+    @Test
+    public void insertDummies(){
+        IntStream.rangeClosed(1, 300).forEach(
+                i->{
+                    Guestbook guestbook = Guestbook.builder()
+                            .title("Title..."+ i)
+                            .content("Content..." + i)
+                            .writer("user" + ( i % 10))
+                            .build();
+                    System.out.println(guestbookRepository.save(guestbook));
+                }
+        );
+    }
+
+    @Test
+    public void updateTest(){
+        Optional<Guestbook> result = guestbookRepository.findById(300L);
+        if (result.isPresent()){
+            Guestbook guestbook = result.get();
+            guestbook.changeTitle("Change Title...");
+            guestbook.changeContent("Change Content...");
+
+            guestbookRepository.save(guestbook);
+
+        }
+    }
+    //'title'로 검색
+    @Test
+    public void testQuery1(){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+        String keyword = "1";
+        BooleanBuilder builder = new BooleanBuilder();
+        BooleanExpression expression = qGuestbook.title.contains(keyword);
+        builder.and(expression);
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
+    }
+    // content로 검색
+    @Test
+    public void testQuery2(){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+        String keyword = "1";
+        BooleanBuilder builder = new BooleanBuilder();
+        BooleanExpression expression = qGuestbook.content.contains(keyword);
+        builder.and(expression);
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
+    }
+    // writer로 검색
+    @Test
+    public void testQuery3(){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+        String keyword = "1";
+        BooleanBuilder builder = new BooleanBuilder();
+        BooleanExpression expression = qGuestbook.writer.contains(keyword);
+        builder.and(expression);
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
+    }
+
+    // 다중 항목 테스트
+    @Test
+    public void testQuery4(){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+
+        QGuestbook qGuestbook = QGuestbook.guestbook;
+
+        String keyword = "1";
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        BooleanExpression exTitle = qGuestbook.title.contains(keyword);
+        BooleanExpression exContent = qGuestbook.content.contains(keyword);
+        BooleanExpression exAll = exTitle.or(exContent);
+        builder.and(exAll);
+        builder.and(qGuestbook.gno.gt(0L));
+
+        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+
+        result.stream().forEach(guestbook -> {
+            System.out.println(guestbook);
+        });
+    }
+
+
+}


### PR DESCRIPTION
제목/ 내용/ 작성자 와 같이 단 하나의 항목으로 검색하는 경우
'제목+내용' / '내용+ 작성자' / '제목+ 작성자'와 같이 2개의 항목으로 검색하는 경우
'제목+ 내용 + 작성자'와 같이 3개의 항목으로 검색하는 경우 만일 Guestbook 엔티티 클래스에 많은 멤버 변수들이 선언 되어 있었다면 이러한 조합 수는 엄청 많아지게 됩니다. 이런 상황을 대비하여 상황에 맞게 쿼리를 처리할 수 있는 Qureydsl이 필요합니다.