### PR TITLE
등록과 DTO를 엔티티로 변환하기

### DIFF
--- a/src/main/java/com/example/guestbook/dto/GuestbookDTO.java
+++ b/src/main/java/com/example/guestbook/dto/GuestbookDTO.java
@@ -1,0 +1,21 @@
+package com.example.guestbook.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class GuestbookDTO {
+
+    private Long gno;
+    private String title;
+    private String content;
+    private String writer;
+    private LocalDateTime regDate, modDate;
+}

--- a/src/main/java/com/example/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/example/guestbook/service/GuestbookService.java
@@ -1,0 +1,17 @@
+package com.example.guestbook.service;
+
+import com.example.guestbook.dto.GuestbookDTO;
+import com.example.guestbook.entity.Guestbook;
+
+public interface GuestbookService {
+    Long register(GuestbookDTO guestbookDTO);
+    default Guestbook dtoToEntity(GuestbookDTO dto){
+        Guestbook entity = Guestbook.builder()
+                .gno(dto.getGno())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .writer(dto.getWriter())
+                .build();
+        return entity;
+    }
+}

--- a/src/main/java/com/example/guestbook/service/GuestbookServiceImpl.java
+++ b/src/main/java/com/example/guestbook/service/GuestbookServiceImpl.java
@@ -1,0 +1,27 @@
+package com.example.guestbook.service;
+
+import com.example.guestbook.dto.GuestbookDTO;
+import com.example.guestbook.entity.Guestbook;
+import com.example.guestbook.repository.GuestbookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class GuestbookServiceImpl implements GuestbookService{
+
+    private final GuestbookRepository repository;
+
+    @Override
+    public Long register(GuestbookDTO dto){
+        log.info("DTO-------------------");
+        log.info(dto);
+        Guestbook entity = dtoToEntity(dto);
+        log.info(entity);
+        repository.save(entity);
+        return entity.getGno();
+
+    }
+}

--- a/src/test/java/com/example/guestbook/service/GuestbookServiceTest.java
+++ b/src/test/java/com/example/guestbook/service/GuestbookServiceTest.java
@@ -1,0 +1,26 @@
+package com.example.guestbook.service;
+
+import com.example.guestbook.dto.GuestbookDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class GuestbookServiceTest {
+
+    @Autowired
+    private GuestbookService service;
+
+    @Test
+    public void testRegister() {
+        GuestbookDTO guestbookDTO = GuestbookDTO.builder()
+                .title("Sample title..")
+                .content("Sample content...")
+                .writer("user0")
+                .build();
+        System.out.println(service.register(guestbookDTO));
+    }
+
+}


### PR DESCRIPTION
default : 자바 8 부터는 안터페이스의 실제 내용을 가지는 코드를 default라는 키워드로 생성할 수 잇다. 이를 이용하면 기존의 추상클래스를 통해서 전달해야 하는 실제 코드를 인터페이스에서 선언할 수 있다.이를 통해서 추상클래스를 생략하는 것이 가능하다