### PR TITLE
연관관계와 관계형데이터베이스 설계

### DIFF
--- a/src/main/java/com/example/guestbook/entity/Guestbook.java
+++ b/src/main/java/com/example/guestbook/entity/Guestbook.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString
+@ToString(exclude = "writer")
 public class Guestbook extends BaseEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,8 +21,9 @@ public class Guestbook extends BaseEntity{
     @Column(length = 1500, nullable = false)
     private String content;
 
-    @Column(length = 50, nullable = false)
-    private String writer;
+//    @Column(length = 50, nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member writer;
 
     public void changeTitle(String title){
         this.title = title;

--- a/src/main/java/com/example/guestbook/entity/Member.java
+++ b/src/main/java/com/example/guestbook/entity/Member.java
@@ -1,0 +1,22 @@
+package com.example.guestbook.entity;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString
+public class Member extends BaseEntity{
+    @Id
+    private String email;
+
+    private String password;
+
+    private String name;
+
+}

--- a/src/main/java/com/example/guestbook/entity/Reply.java
+++ b/src/main/java/com/example/guestbook/entity/Reply.java
@@ -1,0 +1,25 @@
+package com.example.guestbook.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@ToString(exclude = "guestbook")
+public class Reply extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long rno;
+
+    private String text;
+
+    private String replyer;
+
+    @ManyToOne
+    private Guestbook guestbook;
+
+}

--- a/src/main/java/com/example/guestbook/repository/GuestbookRepository.java
+++ b/src/main/java/com/example/guestbook/repository/GuestbookRepository.java
@@ -1,8 +1,33 @@
 package com.example.guestbook.repository;
 
 import com.example.guestbook.entity.Guestbook;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GuestbookRepository extends JpaRepository<Guestbook, Long>, QuerydslPredicateExecutor<Guestbook> {
+    @Query("select g, w from Guestbook g left  join g.writer w where g.gno =:gno")
+    Object getGuestbookWithWriter(@Param("gno") Long gno);
+
+    @Query("SELECT g, r From Guestbook g LEFT JOIN Reply r ON r.guestbook = g WHERE g.gno = :gno")
+    List<Object[]> getGuestbookWithReply(@Param("gno") Long gno);
+
+    @Query(value = "SELECT g, w, count(r)"+
+    "FROM Guestbook g "+
+    " LEFT JOIN g.writer w"+
+    " LEFT JOIN Reply r ON r.guestbook = g " +
+    "GROUP BY g",
+            countQuery = "SELECT count(g) FROM Guestbook g")
+    Page <Object[]> getGuestbookWithReplyCount(Pageable pageable);
+
+    @Query("SELECT g, w, count(r)" +
+    "FROM Guestbook g LEFT JOIN g.writer w "+
+    "LEFT OUTER JOIN Reply r ON r.guestbook = g "+
+            " WHERE g.gno = :gno")
+    Object getBoardByGno(@Param("gno") Long gno);
 }

--- a/src/main/java/com/example/guestbook/repository/MemberRepository.java
+++ b/src/main/java/com/example/guestbook/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Guestbook;
+import com.example.guestbook.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, String > {
+}

--- a/src/main/java/com/example/guestbook/repository/ReplyRepository.java
+++ b/src/main/java/com/example/guestbook/repository/ReplyRepository.java
@@ -1,0 +1,7 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Reply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReplyRepository extends JpaRepository<Reply, Long> {
+}

--- a/src/main/java/com/example/guestbook/service/GuestbookService.java
+++ b/src/main/java/com/example/guestbook/service/GuestbookService.java
@@ -18,7 +18,7 @@ public interface GuestbookService {
                 .gno(dto.getGno())
                 .title(dto.getTitle())
                 .content(dto.getContent())
-                .writer(dto.getWriter())
+//                .writer(dto.getWriter())
                 .build();
         return entity;
     }
@@ -28,7 +28,7 @@ public interface GuestbookService {
                 .gno(entity.getGno())
                 .title(entity.getTitle())
                 .content(entity.getContent())
-                .writer(entity.getWriter())
+//                .writer(entity.getWriter())
                 .regDate(entity.getRegDate())
                 .modDate(entity.getModDate())
                 .build();

--- a/src/main/java/com/example/guestbook/service/GuestbookServiceImpl.java
+++ b/src/main/java/com/example/guestbook/service/GuestbookServiceImpl.java
@@ -100,9 +100,9 @@ public class GuestbookServiceImpl implements GuestbookService{
             conditionBuilder.or(qGuestbook.content.contains(keyword));
         }
 
-        if (type.contains("w")){
-            conditionBuilder.or(qGuestbook.writer.contains(keyword));
-        }
+//        if (type.contains("w")){
+//            conditionBuilder.or(qGuestbook.writer.contains(keyword));
+//        }
 
         booleanBuilder.and(conditionBuilder);
         return booleanBuilder;

--- a/src/test/java/com/example/guestbook/repository/GuestbookRepositoryTest.java
+++ b/src/test/java/com/example/guestbook/repository/GuestbookRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.example.guestbook.repository;
 
 import com.example.guestbook.entity.Guestbook;
+import com.example.guestbook.entity.Member;
 import com.example.guestbook.entity.QGuestbook;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -11,7 +12,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
@@ -23,107 +27,154 @@ public class GuestbookRepositoryTest {
     @Autowired
     private GuestbookRepository guestbookRepository;
 
+
     @Test
     public void insertDummies(){
-        IntStream.rangeClosed(1, 300).forEach(
-                i->{
-                    Guestbook guestbook = Guestbook.builder()
-                            .title("Title..."+ i)
-                            .content("Content..." + i)
-                            .writer("user" + ( i % 10))
-                            .build();
-                    System.out.println(guestbookRepository.save(guestbook));
-                }
-        );
+        IntStream.rangeClosed(1, 300).forEach( i-> {
+
+            Member member = Member.builder()
+                    .email("user" + i + "aaa.com")
+                    .build();
+
+                Guestbook guestbook = Guestbook.builder()
+                        .title("Title..."+ i)
+                        .content("Content..." + i)
+                        .writer(member)
+                        .build();
+              guestbookRepository.save(guestbook);
+        });
+    }
+
+    @Transactional
+    @Test
+    public void testRead1(){
+        Optional<Guestbook> result = guestbookRepository.findById(100L);
+        Guestbook guestbook  = result.get();
+        System.out.println(guestbook);
+        System.out.println(guestbook.getWriter());
     }
 
     @Test
-    public void updateTest(){
-        Optional<Guestbook> result = guestbookRepository.findById(300L);
-        if (result.isPresent()){
-            Guestbook guestbook = result.get();
-            guestbook.changeTitle("Change Title...");
-            guestbook.changeContent("Change Content...");
+    public void testReadWithWriter(){
+        Object result = guestbookRepository.getGuestbookWithWriter(100L);
+        Object[] arr = (Object[]) result;
 
-            guestbookRepository.save(guestbook);
+        System.out.println('-');
+        System.out.println(Arrays.toString(arr));
+    }
 
+    @Test
+    public void testGetGuestbookWithReply(){
+        List<Object[]> result = guestbookRepository.getGuestbookWithReply(30L);
+        for(Object[] arr :result){
+            System.out.println(Arrays.toString(arr));
         }
     }
+    
+    @Test
+    public void testWithReplyCount(){
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+        
+        Page<Object[]> result = guestbookRepository.getGuestbookWithReplyCount(pageable);
+        result.get().forEach(row ->{
+            Object [] arr = (Object[]) row;
+            System.out.println(Arrays.toString(arr));
+        });
+    }
+
+    @Test
+    public void testRead3(){
+        Object result = guestbookRepository.getBoardByGno(30L);
+        Object[] arr = (Object[]) result;
+        System.out.println(Arrays.toString(arr));
+    }
+//    @Test
+//    public void updateTest(){
+//        Optional<Guestbook> result = guestbookRepository.findById(300L);
+//        if (result.isPresent()){
+//            Guestbook guestbook = result.get();
+//            guestbook.changeTitle("Change Title...");
+//            guestbook.changeContent("Change Content...");
+//
+//            guestbookRepository.save(guestbook);
+//
+//        }
+//    }
     //'title'로 검색
-    @Test
-    public void testQuery1(){
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
-
-        QGuestbook qGuestbook = QGuestbook.guestbook;
-        String keyword = "1";
-        BooleanBuilder builder = new BooleanBuilder();
-        BooleanExpression expression = qGuestbook.title.contains(keyword);
-        builder.and(expression);
-
-        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
-
-        result.stream().forEach(guestbook -> {
-            System.out.println(guestbook);
-        });
-    }
+//    @Test
+//    public void testQuery1(){
+//        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+//
+//        QGuestbook qGuestbook = QGuestbook.guestbook;
+//        String keyword = "1";
+//        BooleanBuilder builder = new BooleanBuilder();
+//        BooleanExpression expression = qGuestbook.title.contains(keyword);
+//        builder.and(expression);
+//
+//        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+//
+//        result.stream().forEach(guestbook -> {
+//            System.out.println(guestbook);
+//        });
+//    }
     // content로 검색
-    @Test
-    public void testQuery2(){
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
-
-        QGuestbook qGuestbook = QGuestbook.guestbook;
-        String keyword = "1";
-        BooleanBuilder builder = new BooleanBuilder();
-        BooleanExpression expression = qGuestbook.content.contains(keyword);
-        builder.and(expression);
-
-        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
-
-        result.stream().forEach(guestbook -> {
-            System.out.println(guestbook);
-        });
-    }
-    // writer로 검색
-    @Test
-    public void testQuery3(){
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
-
-        QGuestbook qGuestbook = QGuestbook.guestbook;
-        String keyword = "1";
-        BooleanBuilder builder = new BooleanBuilder();
-        BooleanExpression expression = qGuestbook.writer.contains(keyword);
-        builder.and(expression);
-
-        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
-
-        result.stream().forEach(guestbook -> {
-            System.out.println(guestbook);
-        });
-    }
+//    @Test
+//    public void testQuery2(){
+//        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+//
+//        QGuestbook qGuestbook = QGuestbook.guestbook;
+//        String keyword = "1";
+//        BooleanBuilder builder = new BooleanBuilder();
+//        BooleanExpression expression = qGuestbook.content.contains(keyword);
+//        builder.and(expression);
+//
+//        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+//
+//        result.stream().forEach(guestbook -> {
+//            System.out.println(guestbook);
+//        });
+//    }
+//    // writer로 검색
+//    @Test
+//    public void testQuery3(){
+//        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+//
+//        QGuestbook qGuestbook = QGuestbook.guestbook;
+//        String keyword = "1";
+//        BooleanBuilder builder = new BooleanBuilder();
+//        BooleanExpression expression = qGuestbook.writer.contains(keyword);
+//        builder.and(expression);
+//
+//        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+//
+//        result.stream().forEach(guestbook -> {
+//            System.out.println(guestbook);
+//        });
+//    }
 
     // 다중 항목 테스트
-    @Test
-    public void testQuery4(){
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
-
-        QGuestbook qGuestbook = QGuestbook.guestbook;
-
-        String keyword = "1";
-
-        BooleanBuilder builder = new BooleanBuilder();
-
-        BooleanExpression exTitle = qGuestbook.title.contains(keyword);
-        BooleanExpression exContent = qGuestbook.content.contains(keyword);
-        BooleanExpression exAll = exTitle.or(exContent);
-        builder.and(exAll);
-        builder.and(qGuestbook.gno.gt(0L));
-
-        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
-
-        result.stream().forEach(guestbook -> {
-            System.out.println(guestbook);
-        });
-    }
+//    @Test
+//    public void testQuery4(){
+//        Pageable pageable = PageRequest.of(0, 10, Sort.by("gno").descending());
+//
+//        QGuestbook qGuestbook = QGuestbook.guestbook;
+//
+//        String keyword = "1";
+//
+//        BooleanBuilder builder = new BooleanBuilder();
+//
+//        BooleanExpression exTitle = qGuestbook.title.contains(keyword);
+//        BooleanExpression exContent = qGuestbook.content.contains(keyword);
+//        BooleanExpression exAll = exTitle.or(exContent);
+//        builder.and(exAll);
+//        builder.and(qGuestbook.gno.gt(0L));
+//
+//        Page<Guestbook> result = guestbookRepository.findAll(builder, pageable);
+//
+//        result.stream().forEach(guestbook -> {
+//            System.out.println(guestbook);
+//        });
+//    }
 
 
 }

--- a/src/test/java/com/example/guestbook/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/example/guestbook/repository/MemberRepositoryTest.java
@@ -1,0 +1,30 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Member;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+public class MemberRepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository ;
+
+    @Test
+    public void insertMembers(){
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            Member member = Member.builder()
+                    .email("user" + i + "aaa.com")
+                    .password("1111")
+                    .name("USER " + i)
+                    .build();
+            memberRepository.save(member);
+
+        });
+    }
+
+}

--- a/src/test/java/com/example/guestbook/repository/ReplyRepositoryTest.java
+++ b/src/test/java/com/example/guestbook/repository/ReplyRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.example.guestbook.repository;
+
+import com.example.guestbook.entity.Guestbook;
+import com.example.guestbook.entity.Member;
+import com.example.guestbook.entity.Reply;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+class ReplyRepositoryTest {
+    @Autowired
+    private ReplyRepository replyRepository;
+
+
+
+    @Test
+    public void insertReply(){
+        IntStream.rangeClosed(1, 100).forEach(i -> {
+            long gno = (long)(Math.random()*100 )+1;
+            Guestbook guestbook = Guestbook.builder().gno(gno).build();
+            Reply reply = Reply.builder()
+                    .text("Reply..." + i )
+                    .guestbook(guestbook)
+                    .replyer("guest")
+                    .build();
+            replyRepository.save(reply);
+
+        });
+    }
+
+    @Test
+    public void readReply1(){
+        Optional<Reply> result = replyRepository.findById(1L);
+        Reply reply = result.get();
+
+        System.out.println(reply);
+        System.out.println(reply.getGuestbook());
+    }
+
+}


### PR DESCRIPTION
즉시로딩 -> 연관정보 모두 가져옴
실제 엔티티의 연관관계가 깊어지면 연관된 모든 엔티티 조회
그리고 그 엔티티를 조회할 때 따로 따로 조회하므로 n+1문제 발생
지연로딩 -> 프록시로 조회
트랜잭션 -> 지연로딩에서 데이터베이스 한번 더 작동하게 하는것
JPQL left join -> 엔티티 안에 연관관계 있을때
left join on -> 연관관계없을떄